### PR TITLE
Turn on filter duplicates for all hurco machines

### DIFF
--- a/mtconnect/agent/agent.cfg
+++ b/mtconnect/agent/agent.cfg
@@ -24,26 +24,31 @@ Adapters {
 	}
 
 	Hurco01 {
+		FilterDuplicates = true
 		Host = 127.0.0.1
 		Port = 7882
 	}
 
 	Hurco02 {
+		FilterDuplicates = true
 		Host = 127.0.0.1
 		Port = 7883
 	}
 
 	Hurco03 {
+		FilterDuplicates = true
 		Host = 127.0.0.1
 		Port = 7884
 	}
 
 	Hurco04 {
+		FilterDuplicates = true
 		Host = 127.0.0.1
 		Port = 7885
 	}
 
 	Hurco06 {
+		FilterDuplicates = true
 		Host = 127.0.0.1
 		Port = 7887
 	}


### PR DESCRIPTION
Added filter duplicates to agent configuration to remove all the noise from the hurco adapter.